### PR TITLE
Fixed issues with missing properties in error object

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,88 +1,84 @@
 // Author: Boy Baukema
 // Modifications for Jenkins JSHint reporter: Sublimeye, Roman Morozov <sublimeye.ua@gmail.com>
 
-module.exports =
-{
-	reporter: function(results, data, opts) {
-		"use strict";
+module.exports = {
+    reporter: function (results) {
+        'use strict';
 
-		var files = {},
-				out = [],
-				pairs = {
-					"&": "&amp;",
-					'"': "&quot;",
-					"'": "&apos;",
-					"<": "&lt;",
-					">": "&gt;"
-				},
-		/* these codes parsed by Jenkins JSHint plugin */
-				severityCodes = {
-					'e': 'error',
-					'w': 'warning',
-					'i': 'info'
-				},
-				file, severity, message, line, column, source;
+        var files = {}, out = [], pairs = {
+                '&': '&amp;',
+                '"': '&quot;',
+                '\'': '&apos;',
+                '<': '&lt;',
+                '>': '&gt;'
+            }, /* these codes parsed by Jenkins JSHint plugin */
+            severityCodes = {
+                'e': 'error',
+                'w': 'warning',
+                'i': 'info'
+            }, severity, message, line, column, source;
 
-		function encode (s) {
-			for (var r in pairs) {
-				if (typeof(s) !== "undefined") {
-					s = s.replace(new RegExp(r, "g"), pairs[r]);
-				}
-			}
-			return s || "";
-		}
+        function encode(s) {
+            for (var r in pairs) {
+                if (pairs.hasOwnProperty(r)) {
+                    if (typeof(s) !== 'undefined') {
+                        s = s.replace(new RegExp(r, 'g'), pairs[r]);
+                    }
+                }
+            }
+            return s || '';
+        }
 
-		function getSeverity (code) {
-			return severityCodes[ code.charAt(0).toLowerCase() ] || '';
-		}
+        function getSeverity(code) {
+            return severityCodes[code.charAt(0).toLowerCase()] || '';
+        }
 
-		function makeAttribute(attr, valueObject) {
-			if (!valueObject[attr]) {
-				throw Error('No property '+attr+' in error object');
-			}
+        function makeAttribute(attr, valueObject) {
+            if (valueObject[attr]) {
+                return ' ' + attr + '="' + valueObject[attr] + '"';
+            }
+            return '';
+        }
 
-			return ' ' + attr + '="'+valueObject[attr]+'"';
-		}
+        results.forEach(function (result) {
+            // Register the file
+            result.file = result.file.replace(/^\.\//, '');
+            if (!files[result.file]) {
+                files[result.file] = [];
+            }
 
-		results.forEach(function(result) {
-			// Register the file
-			result.file = result.file.replace(/^\.\//, '');
-			if (!files[result.file]) {
-				files[result.file] = [];
-			}
+            // Add the error
+            files[result.file].push({
+                line    : result.error.line,
+                column  : result.error.character,
+                severity: getSeverity(result.error.code),
+                message : encode(result.error.reason),
+                source  : 'jshint.' + result.error.code
+            });
+        });
 
-			// Add the error
-			files[result.file].push({
-				line: result.error.line,
-				column: result.error.character,
-				severity: getSeverity(result.error.code),
-				message: encode(result.error.reason),
-				source: 'jshint.' + result.error.code
-			});
-		});
+        out.push('<?xml version=\"1.0\" encoding=\"utf-8\"?>');
+        out.push('<checkstyle version=\"4.3\">');
 
-		out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-		out.push("<checkstyle version=\"4.3\">");
+        Object.keys(files).forEach(function (file) {
+            out.push('\t<file name="' + file + '">');
 
-		Object.keys(files).forEach(function(file) {
-			out.push('\t<file name="' + file + '">');
+            files[file].forEach(function (error) {
 
-			files[file].forEach(function(error) {
+                line = makeAttribute('line', error);
+                column = makeAttribute('column', error);
+                severity = makeAttribute('severity', error);
+                message = makeAttribute('message', error);
+                source = makeAttribute('source', error);
 
-				line = makeAttribute('line', error);
-				column = makeAttribute('column', error);
-				severity = makeAttribute('severity', error);
-				message = makeAttribute('message', error);
-				source = makeAttribute('source', error);
+                out.push('\t\t<error' + line + column + severity + message + source + ' />');
+            });
 
-				out.push('\t\t<error' + line + column + severity + message + source + ' />');
-			});
+            out.push('\t</file>');
+        });
 
-			out.push('\t</file>');
-		});
+        out.push('</checkstyle>');
 
-		out.push("</checkstyle>");
-
-		process.stdout.write(out.join("\n") + "\n");
-	}
+        process.stdout.write(out.join('\n') + '\n');
+    }
 };

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,84 +1,87 @@
 // Author: Boy Baukema
 // Modifications for Jenkins JSHint reporter: Sublimeye, Roman Morozov <sublimeye.ua@gmail.com>
 
-module.exports = {
-    reporter: function (results) {
-        'use strict';
+module.exports =
+{
+	reporter: function(results, data, opts) {
+		"use strict";
 
-        var files = {}, out = [], pairs = {
-                '&': '&amp;',
-                '"': '&quot;',
-                '\'': '&apos;',
-                '<': '&lt;',
-                '>': '&gt;'
-            }, /* these codes parsed by Jenkins JSHint plugin */
-            severityCodes = {
-                'e': 'error',
-                'w': 'warning',
-                'i': 'info'
-            }, severity, message, line, column, source;
+		var files = {},
+				out = [],
+				pairs = {
+					"&": "&amp;",
+					'"': "&quot;",
+					"'": "&apos;",
+					"<": "&lt;",
+					">": "&gt;"
+				},
+		/* these codes parsed by Jenkins JSHint plugin */
+				severityCodes = {
+					'e': 'error',
+					'w': 'warning',
+					'i': 'info'
+				},
+				file, severity, message, line, column, source;
 
-        function encode(s) {
-            for (var r in pairs) {
-                if (pairs.hasOwnProperty(r)) {
-                    if (typeof(s) !== 'undefined') {
-                        s = s.replace(new RegExp(r, 'g'), pairs[r]);
-                    }
-                }
-            }
-            return s || '';
-        }
+		function encode (s) {
+			for (var r in pairs) {
+				if (typeof(s) !== "undefined") {
+					s = s.replace(new RegExp(r, "g"), pairs[r]);
+				}
+			}
+			return s || "";
+		}
 
-        function getSeverity(code) {
-            return severityCodes[code.charAt(0).toLowerCase()] || '';
-        }
+		function getSeverity (code) {
+			return severityCodes[ code.charAt(0).toLowerCase() ] || '';
+		}
 
-        function makeAttribute(attr, valueObject) {
-            if (valueObject[attr]) {
-                return ' ' + attr + '="' + valueObject[attr] + '"';
-            }
-            return '';
-        }
+		function makeAttribute(attr, valueObject) {
+			if (valueObject[attr]) {
+				return ' ' + attr + '="' + valueObject[attr] + '"';
+			}
+			return '';
+		}
 
-        results.forEach(function (result) {
-            // Register the file
-            result.file = result.file.replace(/^\.\//, '');
-            if (!files[result.file]) {
-                files[result.file] = [];
-            }
+		results.forEach(function(result) {
+			// Register the file
+			result.file = result.file.replace(/^\.\//, '');
+			if (!files[result.file]) {
+				files[result.file] = [];
+			}
 
-            // Add the error
-            files[result.file].push({
-                line    : result.error.line,
-                column  : result.error.character,
-                severity: getSeverity(result.error.code),
-                message : encode(result.error.reason),
-                source  : 'jshint.' + result.error.code
-            });
-        });
+			// Add the error
+			files[result.file].push({
+				line: result.error.line,
+				column: result.error.character,
+				severity: getSeverity(result.error.code),
+				message: encode(result.error.reason),
+				source: 'jshint.' + result.error.code
+			});
+		});
 
-        out.push('<?xml version=\"1.0\" encoding=\"utf-8\"?>');
-        out.push('<checkstyle version=\"4.3\">');
+		out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+		out.push("<checkstyle version=\"4.3\">");
 
-        Object.keys(files).forEach(function (file) {
-            out.push('\t<file name="' + file + '">');
+		Object.keys(files).forEach(function(file) {
+			out.push('\t<file name="' + file + '">');
 
-            files[file].forEach(function (error) {
+			files[file].forEach(function(error) {
 
-                line = makeAttribute('line', error);
-                column = makeAttribute('column', error);
-                severity = makeAttribute('severity', error);
-                message = makeAttribute('message', error);
-                source = makeAttribute('source', error);
+				line = makeAttribute('line', error);
+				column = makeAttribute('column', error);
+				severity = makeAttribute('severity', error);
+				message = makeAttribute('message', error);
+				source = makeAttribute('source', error);
 
-                out.push('\t\t<error' + line + column + severity + message + source + ' />');
-            });
+				out.push('\t\t<error' + line + column + severity + message + source + ' />');
+			});
 
-            out.push('\t</file>');
-        });
+			out.push('\t</file>');
+		});
 
-        out.push('</checkstyle>');
+		out.push("</checkstyle>");
 
-        process.stdout.write(out.join('\n') + '\n');
-    }
+		process.stdout.write(out.join("\n") + "\n");
+	}
 };


### PR DESCRIPTION
Before fix I get the following error: No property column in error object at Error (<anonymous>) at makeAttribute (/node_modules/jshint-jenkins-checkstyle-reporter/src/reporter.js:41:11)
After fix I get the checkstyle-jshint.xml generated correctly.
This is due to attribute "column" not always being defined in the error object.
