### PR TITLE
Improve object property detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jshint-jenkins-checkstyle-reporter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JSHint reporter with better support for Jenkins Checkstyle plugin",
   "main": "src/index.js",
   "scripts": {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -37,7 +37,7 @@ module.exports =
 		}
 
 		function makeAttribute(attr, valueObject) {
-			if (!valueObject[attr]) {
+			if (!valueObject.hasOwnProperty(attr)) {
 				throw Error('No property '+attr+' in error object');
 			}
 


### PR DESCRIPTION
Testing (!valueObject.[attr]) will return a falsy value if valueObject.[attr] has a
falsy value, such as '0'. See:
http://www.sitepoint.com/javascript-truthy-falsy/

(Fixes #3)
